### PR TITLE
Enabling distributed CPU training in SPT-Code

### DIFF
--- a/sources/args.py
+++ b/sources/args.py
@@ -97,6 +97,16 @@ class RuntimeArguments:
                   'help': 'Whether to use mixed precision'}
     )
 
+    use_ipex: bool = field(
+        default=False,
+        metadata={'help': 'Enable Intel Python extension for acceleration on Intel Xeon CPUs'}
+    )
+
+    do_dist_cpu_training: bool = field(
+        default=False,
+        metadata={'help': 'Enable distributed training over multiple CPUs using Accelerate and Intel IPEX and OneCCL'}
+    )
+
 
 @dataclass
 class DatasetArguments:

--- a/sources/data/vocab.py
+++ b/sources/data/vocab.py
@@ -309,7 +309,7 @@ class Vocab(object):
         vocab_name = name if name else self.name
         vocab_dir = os.path.join(vocab_root, vocab_name)
         if not os.path.exists(vocab_dir) or not os.path.isdir(vocab_dir):
-            os.makedirs(vocab_dir)
+            os.makedirs(vocab_dir, exist_ok=True)
 
         # save pickle file for whole instance
         with open(os.path.join(vocab_dir, '{}.pk'.format(vocab_name)), mode='wb') as f:

--- a/sources/main.py
+++ b/sources/main.py
@@ -71,7 +71,7 @@ if __name__ == '__main__':
     for d in [main_args.checkpoint_root, main_args.model_root, main_args.vocab_root, main_args.tensor_board_root,
               main_args.dataset_save_dir, main_args.vocab_save_dir]:
         if not os.path.exists(d):
-            os.makedirs(d)
+            os.makedirs(d, exist_ok=True)
 
     # cuda and parallel
     if main_args.cuda_visible_devices is not None:

--- a/sources/pre_train.py
+++ b/sources/pre_train.py
@@ -12,6 +12,7 @@ from utils.general import count_params, human_format, layer_wise_parameters
 from utils.trainer import CodeTrainer, CodeCLSTrainer
 from utils.callbacks import LogStateCallBack
 from models.bart import BartForClassificationAndGeneration
+from data.data_collator import collate_fn
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ logger = logging.getLogger(__name__)
 def pre_train(args,
               trained_model: Union[BartForClassificationAndGeneration, str] = None,
               trained_vocab: Union[Tuple[Vocab, Vocab, Vocab], str] = None):
+    print("SPT-Code:pre_train:args", args)
     tasks = args.pre_train_tasks
     if tasks is None:
         logger.warning('Was specified for pre-training, but got pre-training tasks to None, '
@@ -181,7 +183,10 @@ def pre_train(args,
                                               ignore_data_skip=False,
                                               label_smoothing_factor=args.label_smoothing,
                                               report_to=['tensorboard'],
-                                              dataloader_pin_memory=True)
+                                              dataloader_pin_memory=True,
+                                              use_ipex=args.use_ipex,
+                                              log_level='debug',
+                                              ddp_backend='ccl' if args.do_dist_cpu_training else None)
             trainer = CodeCLSTrainer(main_args=args,
                                      code_vocab=code_vocab,
                                      ast_vocab=ast_vocab,
@@ -189,7 +194,12 @@ def pre_train(args,
                                      task=task,
                                      model=model,
                                      args=training_args,
-                                     data_collator=None,
+                                     data_collator=lambda batch: collate_fn(batch,
+                                                                            args=args,
+                                                                            task=task,
+                                                                            code_vocab=code_vocab,
+                                                                            nl_vocab=nl_vocab,
+                                                                            ast_vocab=ast_vocab),
                                      train_dataset=dataset,
                                      tokenizer=nl_vocab,
                                      model_init=None,
@@ -238,7 +248,10 @@ def pre_train(args,
                                                      ignore_data_skip=False,
                                                      label_smoothing_factor=args.label_smoothing,
                                                      report_to=['tensorboard'],
-                                                     dataloader_pin_memory=True)
+                                                     dataloader_pin_memory=True,
+                                                     use_ipex=args.use_ipex,
+                                                     log_level='debug',
+                                                     ddp_backend='ccl' if args.do_dist_cpu_training else None)
             trainer = CodeTrainer(main_args=args,
                                   code_vocab=code_vocab,
                                   ast_vocab=ast_vocab,
@@ -246,7 +259,12 @@ def pre_train(args,
                                   task=task,
                                   model=model,
                                   args=training_args,
-                                  data_collator=None,
+                                  data_collator=lambda batch: collate_fn(batch,
+                                                                            args=args,
+                                                                            task=task,
+                                                                            code_vocab=code_vocab,
+                                                                            nl_vocab=nl_vocab,
+                                                                            ast_vocab=ast_vocab),
                                   train_dataset=dataset,
                                   tokenizer=nl_vocab,
                                   model_init=None,
@@ -297,7 +315,10 @@ def pre_train(args,
                                                      ignore_data_skip=False,
                                                      label_smoothing_factor=args.label_smoothing,
                                                      report_to=['tensorboard'],
-                                                     dataloader_pin_memory=True)
+                                                     dataloader_pin_memory=True,
+                                                     use_ipex=args.use_ipex,
+                                                     log_level='debug',
+                                                     ddp_backend='ccl' if args.do_dist_cpu_training else None)
             trainer = CodeTrainer(main_args=args,
                                   code_vocab=code_vocab,
                                   ast_vocab=ast_vocab,
@@ -305,7 +326,12 @@ def pre_train(args,
                                   task=task,
                                   model=model,
                                   args=training_args,
-                                  data_collator=None,
+                                  data_collator=lambda batch: collate_fn(batch,
+                                                                            args=args,
+                                                                            task=task,
+                                                                            code_vocab=code_vocab,
+                                                                            nl_vocab=nl_vocab,
+                                                                            ast_vocab=ast_vocab),
                                   train_dataset=dataset,
                                   tokenizer=nl_vocab,
                                   model_init=None,

--- a/sources/utils/trainer.py
+++ b/sources/utils/trainer.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from data.data_collator import collate_fn
 
-
 class CodeTrainer(Seq2SeqTrainer):
 
     def __init__(self, main_args: argparse.Namespace, code_vocab, ast_vocab, nl_vocab, task, **kwargs):
@@ -18,48 +17,6 @@ class CodeTrainer(Seq2SeqTrainer):
         self.ast_vocab = ast_vocab
         self.nl_vocab = nl_vocab
         self.task = task
-
-    def get_train_dataloader(self) -> DataLoader:
-        """
-        Returns the training :class:`~torch.utils.data.DataLoader`.
-
-        Will use no sampler if :obj:`self.train_dataset` does not implement :obj:`__len__`, a random sampler (adapted
-        to distributed training if necessary) otherwise.
-
-        Subclass and override this method if you want to inject some custom behavior.
-        """
-
-        return DataLoader(dataset=self.train_dataset,
-                          batch_size=self.main_args.batch_size,
-                          shuffle=True,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
-
-    def get_eval_dataloader(self, eval_dataset: Optional[Dataset] = None) -> DataLoader:
-        if eval_dataset:
-            self.eval_dataset = eval_dataset
-        return DataLoader(dataset=self.eval_dataset,
-                          batch_size=self.main_args.eval_batch_size,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
-
-    def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
-        return DataLoader(dataset=test_dataset,
-                          batch_size=self.main_args.eval_batch_size,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
 
     def set_task(self, task):
         self.task = task
@@ -74,48 +31,6 @@ class CodeCLSTrainer(Trainer):
         self.ast_vocab = ast_vocab
         self.nl_vocab = nl_vocab
         self.task = task
-
-    def get_train_dataloader(self) -> DataLoader:
-        """
-        Returns the training :class:`~torch.utils.data.DataLoader`.
-
-        Will use no sampler if :obj:`self.train_dataset` does not implement :obj:`__len__`, a random sampler (adapted
-        to distributed training if necessary) otherwise.
-
-        Subclass and override this method if you want to inject some custom behavior.
-        """
-
-        return DataLoader(dataset=self.train_dataset,
-                          batch_size=self.main_args.batch_size,
-                          shuffle=True,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
-
-    def get_eval_dataloader(self, eval_dataset: Optional[Dataset] = None) -> DataLoader:
-        if eval_dataset:
-            self.eval_dataset = eval_dataset
-        return DataLoader(dataset=self.eval_dataset,
-                          batch_size=self.main_args.eval_batch_size,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
-
-    def get_test_dataloader(self, test_dataset: Dataset) -> DataLoader:
-        return DataLoader(dataset=test_dataset,
-                          batch_size=self.main_args.eval_batch_size,
-                          collate_fn=lambda batch: collate_fn(batch,
-                                                              args=self.main_args,
-                                                              task=self.task,
-                                                              code_vocab=self.code_vocab,
-                                                              nl_vocab=self.nl_vocab,
-                                                              ast_vocab=self.ast_vocab))
 
     def set_task(self, task):
         self.task = task


### PR DESCRIPTION
This enablement required removing DataLoader in SPT-Code as it was not handling batch size for distributed training correctly. Default DataLoader in Hugging Face's Transformer handles it correctly. We just need to pass collate_fn to it.